### PR TITLE
Update to elixir 1.7

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -5,6 +5,7 @@ locals_without_parens = [
 ]
 
 [
+  inputs: ["mix.exs", "{config,lib.test}/**/*{ex,exs}"],
   locals_without_parens: locals_without_parens,
   export: [
     locals_without_parens: locals_without_parens

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,12 @@
+locals_without_parens = [
+  boot_step: 1,
+  boot_step: 2,
+  boot_step: 3
+]
+
+[
+  locals_without_parens: locals_without_parens,
+  export: [
+    locals_without_parens: locals_without_parens
+  ]
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
-language: erlang
-notifications:
-  recipients:
-    - jordan+travis-booter@jordan.io
+language: elixir
+elixir:
+  - '1.7.4'
 otp_release:
-  - 17.0
-before_install:
-  - git clone https://github.com/elixir-lang/elixir
-  - cd elixir
-  - git checkout v1.0
-  - make && cd ..
-before_script: "export PATH=`pwd`/elixir/bin:$PATH"
-script: "mix do local.hex --force, deps.get && mix test"
+  - '21.3.8'
 
+script: 
+  - "MIX_ENV=test mix do local.hex --force, deps.get && mix test"

--- a/lib/booter.ex
+++ b/lib/booter.ex
@@ -185,19 +185,19 @@ defmodule Booter do
       end
     rescue
       error ->
-        handle_error(step, error)
+        handle_error(step, error, __STACKTRACE__)
     catch
       error ->
-        handle_error(step, error)
+        handle_error(step, error, __STACKTRACE__)
     end
   end
 
-  defp handle_error(step, error) do
+  defp handle_error(step, error, stacktrace) do
     if step[:catch] do
       Logger.error("Booter: catched error in #{step}: #{inspect(error)}")
       {:error, step, error}
     else
-      raise Error.StepError, step: step, error: error, stacktrace: System.stacktrace()
+      raise Error.StepError, step: step, error: error, stacktrace: stacktrace
     end
   end
 
@@ -227,9 +227,5 @@ defmodule Booter do
     )
 
     return
-  end
-
-  defp log_boot_failure(step) do
-    Logger.error("Booter: aborted at step #{step}")
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -16,8 +16,8 @@ defmodule Booter.Mixfile do
 
   defp deps do
     [
-      {:earmark, "~> 0.1", only: :dev},
-      {:ex_doc, "~> 0.5", only: :dev},
+      {:earmark, "~> 1.3", only: :dev},
+      {:ex_doc, "~> 0.21", only: :dev, runtime: false}
    ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,12 +2,14 @@ defmodule Booter.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :booter,
-     version: "0.2.0",
-     elixir: "~> 1.4",
-     description: "Boot an Elixir application step by step",
-     package: package(),
-     deps: deps()]
+    [
+      app: :booter,
+      version: "0.2.0",
+      elixir: "~> 1.7",
+      description: "Boot an Elixir application step by step",
+      package: package(),
+      deps: deps()
+    ]
   end
 
   def application do
@@ -18,14 +20,18 @@ defmodule Booter.Mixfile do
     [
       {:earmark, "~> 1.3", only: :dev},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false}
-   ]
+    ]
   end
 
   defp package do
-    [files: ["lib", "mix.exs", "README.md", "LICENSE"],
+    [
+      files: ["lib", "mix.exs", "README.md", "LICENSE"],
       contributors: ["Jordan Bracco", "Jordan Parker"],
       licenses: ["Mozilla Public License 1.1"],
-      links: %{"GitHub" => "https://github.com/eraserewind/booter",
-                "Docs" => "http://eraserewind.github.io/booter"}]
+      links: %{
+        "GitHub" => "https://github.com/hrefhref/booter",
+        "Docs" => "http://hrefhref.github.io/booter"
+      }
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,7 @@
 %{
-  "earmark": {:hex, :earmark, "0.1.12", "ae057eb004b23ecd32125608efbb33be8b924db54e56ae69a8cb113362b2463c", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.6.2", "e51e39a1274201c753754fafd640be217568d552d2a70a2bb69b93d335eb027b", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.21.0", "7af8cd3e3df2fe355e99dabd2d4dcecc6e76eb417200e3b7a3da362d52730e3c", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
 }

--- a/test/booter_test.exs
+++ b/test/booter_test.exs
@@ -5,7 +5,7 @@ defmodule BooterTest do
   alias Booter.Error
 
   defmodule BareModule do
-    Module.register_attribute __MODULE__, :boot_step, accumulate: true, persist: true
+    Module.register_attribute(__MODULE__, :boot_step, accumulate: true, persist: true)
     @boot_step %Step{name: :bare, description: "Bare Step"}
     @boot_step %Step{name: :bare_two, description: "Second Bare Step"}
   end
@@ -19,7 +19,7 @@ defmodule BooterTest do
 
   test "module_steps/1 on a bare module" do
     steps = module_steps(BareModule)
-    assert is_list steps
+    assert is_list(steps)
     assert Enum.count(steps) == 2
     bare = Enum.at(steps, 0)
     assert bare.__struct__ == Step
@@ -27,7 +27,7 @@ defmodule BooterTest do
 
   test "module_steps/1 on a module using boot_step/3 macro" do
     steps = module_steps(MacroModule)
-    assert is_list steps
+    assert is_list(steps)
     assert Enum.count(steps) == 3
 
     # boot_step/3 with (nil, nil, options)
@@ -53,7 +53,7 @@ defmodule BooterTest do
 
   test "modules_steps/1 with given list of module" do
     steps = modules_steps([BareModule, MacroModule])
-    assert is_list steps
+    assert is_list(steps)
     assert Enum.count(steps) == 5
   end
 
@@ -73,8 +73,8 @@ defmodule BooterTest do
   test "ordered_steps/1" do
     unordered_steps = modules_steps([Dependencies])
     steps = ordered_steps(unordered_steps)
-    steps_names = Enum.map(steps, fn(s) -> s.name end)
-    assert is_list steps
+    steps_names = Enum.map(steps, fn s -> s.name end)
+    assert is_list(steps)
     assert Enum.count(unordered_steps) == Enum.count(steps)
     assert steps_names == [:planet, :clouds, :sky, :earth, :rainbow, :unicorn, :moon, :poneys]
   end
@@ -123,7 +123,11 @@ defmodule BooterTest do
   test "boot!/1" do
     steps = module_steps(BootMe)
     return = boot!([BootMe])
-    assert return == [{:ok, Enum.at(steps, 0), "what is the meaning of life"}, {:ok, Enum.at(steps, 1), "42"}]
+
+    assert return == [
+             {:ok, Enum.at(steps, 0), "what is the meaning of life"},
+             {:ok, Enum.at(steps, 1), "42"}
+           ]
   end
 
   defmodule BootSkip do
@@ -144,6 +148,18 @@ defmodule BooterTest do
 
   test "boot!/1 with failing step" do
     assert_raise Error.StepError, fn -> Booter.boot!([BootRaise]) end
+  end
+
+  test "StepError includes a stacktrace" do
+    e =
+      try do
+        Booter.boot!([BootRaise])
+        nil
+      rescue
+        e in [Error.StepError] -> e
+      end
+
+    assert [{:erlang, :binary_to_integer, ["lol, nope"], []} | _] = e.stacktrace
   end
 
   defmodule BootCatch do
@@ -167,5 +183,4 @@ defmodule BooterTest do
     return = boot!([BootWithoutFun])
     assert return == [{:no_mfa, Enum.at(steps, 0), nil}]
   end
-
 end


### PR DESCRIPTION
The library gives the following warnings if used with elixir 1.7+
```
warning: System.stacktrace/0 outside of rescue/catch clauses is deprecated. If you want to support only Elixir v1.7+, you must access __STACKTRACE__ inside a rescue/catch. If you want to support earlier Elixir versions, move System.stacktrace/0 inside a rescue/catch
  lib/booter.ex:200

warning: function log_boot_failure/1 is unused
  lib/booter.ex:232
```
* Removes the unused function
* Replaces the `System.stacktrace/0` call with `__STACKTRACE__`
* Adds formatter config and asds `boot_step/x` to `function_without_parans`

This PR is incompatible with any elixir < 1.7 as it introduced `__STACKTRACE__` deprecated `System.stacktrace/0`.